### PR TITLE
Add bootstrap and refactor existing pages

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -1,3 +1,0 @@
-* {
-    box-sizing: border-box;
-}

--- a/frontend/src/app/features/home-page/home-page.component.html
+++ b/frontend/src/app/features/home-page/home-page.component.html
@@ -1,61 +1,70 @@
 <!-- Home Page -->
 <!-- Who Are We Section -->
-<div class="container w3-animate-opacity">
-  <div class="w3-row w3-center">
-    <div class="w3-col s12 m6">
-      <img class="pic" src="/assets/BirdsViewOfCars.jpg">
-    </div>
-    <div class="w3-col s12 m6">
-      <h1 class="descTitle"><b>Who Are We?</b></h1>
-      <p class="descTxt">Here. There. Everywhere. !app! provides an easy 
-        solution for churches to organize and setup ride accommodations 
-        between fellow members.</p>
-        <p></p>
-      <p class="w3-hide-small descTxt" >Growing up in a more rural college town, dependent 
-        and accessible transportation was lacking in our community. This lack 
-        of transit made it very difficult for people to get to church. It is 
-        in our best hopes that !app! helps resolve this issue.</p>
+<div class="section text-center w3-animate-opacity">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-md-6">
+        <img class="pic" src="/assets/BirdsViewOfCars.jpg">
+      </div>
+      <div class="col-12 col-md-6">
+        <h1 class="descTitle"><b>Who Are We?</b></h1>
+        <p class="descTxt">Here. There. Everywhere. !app! provides an easy 
+          solution for churches to organize and setup ride accommodations 
+          between fellow members.</p>
+          <p></p>
+        <p class="d-none d-md-block descTxt" >Growing up in a more rural college town, dependent 
+          and accessible transportation was lacking in our community. This lack 
+          of transit made it very difficult for people to get to church. It is 
+          in our best hopes that !app! helps resolve this issue.</p>
+      </div>
     </div>
   </div>
 </div>
   <!-- How Do I Get Started -->
-<div class="w3-row midDivider w3-center w3-animate-opacity">
-  <div class="container w3-row w3-center midDivider">
-    <div class="w3-col s12 w3-hide-medium w3-hide-large">
+<div class="section text-center w3-animate-opacity">
+  <div class="container">
+    <div class="row flex-row-reverse">
+      <div class="col-12 col-md-6">
         <img class="pic" src="/assets/CrossQuote.png">
-    </div>
-    <div class="w3-col s12 m6">
-      <h1 class="descTitle w3-center"><b>How Do I Get Started?</b></h1>
-      <p class="descTxt w3-center">No sign up needed! If you are looking for a ride to 
-        church, click the button below and provide some needed pickup 
-        information. Once submitted, a <b>Ride Provider</b> will contact you about 
-        the details.</p>
-      <primary-button text="Find A Ride" [routerLink]="'/find-ride'"></primary-button>
-    </div>
-    <div class="w3-col s12 m5 w3-hide-small">
-      <img class="pic" src="/assets/CrossQuote.png">
+      </div>
+      <div class="col-12 col-md-6">
+        <h1 class="descTitle text-center"><b>How Do I Get Started?</b></h1>
+        <p class="descTxt text-center">No sign up needed! If you are looking for a ride to 
+          church, click the button below and provide some needed pickup 
+          information. Once submitted, a <b>Ride Provider</b> will contact you about 
+          the details.</p>
+        <div class="button-container">
+          <primary-button text="Find A Ride" [routerLink]="'/find-ride'"></primary-button>
+        </div>
+      </div>
     </div>
   </div>
 </div>
 <!-- How Does This Work -->
-<div class="container w3-row w3-animate-opacity">
-  <div class="w3-col s12 m5">
-    <img class="pic" src="/assets/RoofOfTaxi.jpg">
-  </div>
-  <div class="w3-col s12 m7">
-    <h1 class="descTitle w3-center"><b>How Does This Work</b></h1>
-    <p class="descTxt descTxt--bottom"><b>Ride Providers</b> are church members who will be 
-    providing the means of transportation. You can become a Ride 
-    Provider by creating an account and applying to your 
-    corresponding church. Upon approval, you will be able to view 
-    and accept ride requests.</p>
-
-    <p class="descTxt"><b>Church Admins</b> are created by church staff. This
-    allows the management of details on !app! such as service times, 
-    locations, and website links. This information is available 
-    to both Riders and Ride Providers. These Church Admins also manage
-    who can and can’t participate as Ride Providers for their 
-    church.</p>
-    <primary-button text="Sign Up" [routerLink]="'/sign-up'"></primary-button>
+<div class="section w3-animate-opacity">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-md-5">
+        <img class="pic" src="/assets/RoofOfTaxi.jpg">
+      </div>
+      <div class="col-12 col-md-7">
+        <h1 class="descTitle text-center"><b>How Does This Work</b></h1>
+        <p class="descTxt descTxt--bottom"><b>Ride Providers</b> are church members who will be 
+        providing the means of transportation. You can become a Ride 
+        Provider by creating an account and applying to your 
+        corresponding church. Upon approval, you will be able to view 
+        and accept ride requests.</p>
+    
+        <p class="descTxt"><b>Church Admins</b> are created by church staff. This
+        allows the management of details on !app! such as service times, 
+        locations, and website links. This information is available 
+        to both Riders and Ride Providers. These Church Admins also manage
+        who can and can’t participate as Ride Providers for their 
+        church.</p>
+        <div class="button-container">
+          <primary-button text="Sign Up" [routerLink]="'/sign-up'"></primary-button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/features/home-page/home-page.component.scss
+++ b/frontend/src/app/features/home-page/home-page.component.scss
@@ -1,32 +1,70 @@
+@import "../../../utilities/mixins";
+
+.section {
+  padding-top: 64px;
+  padding-bottom: 64px;
+  background-color: var(--background);
+
+  &:nth-child(even) {
+    background-color: var(--secondary);
+  }
+}
+
 .pic{
   width:100%;
-  margin: 64px;
   border-radius: 45px;
 }
 
 .descTitle{
-  margin-top: 64px;
   margin-bottom: 16px;
 }
 
 .descTxt{
-  margin: 0px 90px;
-  margin-bottom: 32px;
-}
-
-.midDivider{
-  background-color: var(--secondary);
+  margin: 0px 64px 32px 64px;
 }
 
 // Responsive
-@media screen and (max-width: 600px) {
+@include responsive(lg) {
+  .descTxt{
+    margin: 0px 32px 32px 32px;
+  }
+}
+
+@include responsive(md) {
+  .descTxt{
+    margin: 0px 16px 32px 16px;
+  }
+}
+
+@include responsive(sm) {
+  .section {
+    padding: 32px;
+  }
+
+  .pic {
+    margin-bottom: 32px;
+  }
+
+  .button-container {
+    margin-bottom: 32px !important;
+  }
+}
+
+@include responsive(xs) {
+  .section {
+    padding: 0;
+
+    .container {
+      padding: 0;
+    }
+  }
+
   .midText{
     width: 100%;
     text-align: center;
   }
 
   .pic{
-    width:100%;
     margin: 0px;
     border-radius: 0px;
   }
@@ -38,5 +76,4 @@
   .descTxt{
     margin: 16px 12px;
   }
-  
 }

--- a/frontend/src/app/features/sign-up-choice/sign-up-choice.component.html
+++ b/frontend/src/app/features/sign-up-choice/sign-up-choice.component.html
@@ -1,34 +1,40 @@
 <!-- Sign Up Choice Page -->
-<div class="sign-up-choice-page container w3-animate-opacity">
-    <div class="w3-row w3-large">
-        <div class="w3-col s12 m6">
-            <a href="/signup/provider" class="choice choice--provider">
-                <img src="/assets/MiniTaxi2.jpg">
-                <div class="text-wrapper text-wrapper--provider">
-                    <h2><strong>Become a Ride Provider</strong></h2>
-                    <p>
-                        <strong>Ride Providers</strong> are church members who will be providing 
-                        the means of transportation. You can become a Ride Provider by creating 
-                        an !app! account and applying to your corresponding church. Upon approval, 
-                        you will be able to view and accept ride requests.
-                    </p>
-                </div>
-            </a>
-        </div>
-        <div class="w3-col s12 m6">
-            <a href="/signup/admin" class="choice choice--admin">
-                <img src="/assets/ChurchFront2.jpg">
-                <div class="text-wrapper text-wrapper--admin">
-                    <h2><strong>Become a Church Admin</strong></h2>
-                    <p>
-                        <strong>Church Admins</strong> are created by church staff. This allows 
-                        the management of details on !app! such as service times, locations, and 
-                        website links. This information is available to both Riders and Ride Providers. 
-                        These Church Admins also manage who can and can't participate as 
-                        Ride Providers for their church.
-                    </p>
-                </div>
-            </a>
-        </div>
+<div class="sign-up-choice-page w3-animate-opacity">
+  <div class="container">
+    <div class="row gx-lg-5 justify-content-center">
+      <div class="col col-12 col-md-6 col-lg-5">
+        <a href="/signup/provider" class="choice choice--provider">
+          <div class="image-container">
+            <img src="/assets/MiniTaxi2.jpg">
+          </div>
+          <div class="text-wrapper text-wrapper--provider">
+            <h2><strong>Become a Ride Provider</strong></h2>
+            <p>
+              <strong>Ride Providers</strong> are church members who will be providing
+              the means of transportation. You can become a Ride Provider by creating
+              an !app! account and applying to your corresponding church. Upon approval,
+              you will be able to view and accept ride requests.
+            </p>
+          </div>
+        </a>
+      </div>
+      <div class="col col-12 col-md-6 col-lg-5">
+        <a href="/signup/admin" class="choice choice--admin">
+          <div class="image-container">
+            <img src="/assets/ChurchFront2.jpg">
+          </div>
+          <div class="text-wrapper text-wrapper--admin">
+            <h2><strong>Become a Church Admin</strong></h2>
+            <p>
+              <strong>Church Admins</strong> are created by church staff. This allows
+              the management of details on !app! such as service times, locations, and
+              website links. This information is available to both Riders and Ride Providers.
+              These Church Admins also manage who can and can't participate as
+              Ride Providers for their church.
+            </p>
+          </div>
+        </a>
+      </div>
     </div>
+  </div>
 </div>

--- a/frontend/src/app/features/sign-up-choice/sign-up-choice.component.scss
+++ b/frontend/src/app/features/sign-up-choice/sign-up-choice.component.scss
@@ -1,63 +1,58 @@
 .sign-up-choice-page {
-    
-    .w3-row {
-        display: flex;
+  background-color: var(--background);
+  padding-top: 16px;
+  padding-bottom: 16px;
+
+  .col {
+    margin-top: 16px;
+    margin-bottom: 16px;
+  }
+
+  .choice {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    border-radius: 16px;
+    color: var(--white);
+    text-decoration: none;
+
+    &--provider {
+      background-color: var(--primary);
     }
 
-    .w3-col {
-        padding: 15px;
-        display: flex;
+    &--admin {
+      background-color: var(--secondary);
     }
 
-    .choice {
-        display: flex;
-        flex-direction: column;
-        margin-left: auto;
-        margin-right: auto;
-        border-radius: 15px;
-        max-width: 500px;
-        color: var(--white);
-        text-decoration: none;
-    
-        &--provider {
-            background-color: var(--primary);
-        }
-    
-        &--admin {
-            background-color: var(--secondary);
-        }
-    
-        img {
-            margin: 15px;
-            width: calc(100% - 30px);
-            border-radius: 15px;
-        }
-    
-        .text-wrapper {
-            flex: 1;
-            margin: 0 15px 15px 15px;
-            padding: 15px;
-            border-radius: 15px;
-            &--provider {
-                background-color: var(--primaryAccent);
-            }
-        
-            &--admin {
-                background-color: var(--secondaryAccent);
-            }
-        }
-    }
-      
-    // Responsive
-    @media screen and (max-width: 900px) {
-        margin: 15px 60px;
+    .image-container {
+      margin: 16px;
+      width: calc(100% - 32px);
+      height: 0;
+      padding-bottom: 75%; /* creates a 4:3 aspect ratio */
+      position: relative;
+
+      img {
+        border-radius: 16px;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
     }
 
-    @media screen and (max-width: 600px) {
-        margin: 15px 0;
+    .text-wrapper {
+      flex: 1;
+      margin: 0 16px 16px 16px;
+      padding: 16px;
+      border-radius: 16px;
 
-        .w3-row {
-            display: initial;
-        }
-    }    
+      &--provider {
+        background-color: var(--primaryAccent);
+      }
+
+      &--admin {
+        background-color: var(--secondaryAccent);
+      }
+    }
+  }
 }

--- a/frontend/src/app/shared/footer/footer.component.html
+++ b/frontend/src/app/shared/footer/footer.component.html
@@ -1,5 +1,5 @@
-<div class="w3-row footer w3-animate-opacity">
-  <div class="w3-col s12">
-    <p class="w3-center txt">©2023 !app! All Rights Reserved.</p>
+<div class="row footer w3-animate-opacity">
+  <div class="col-12">
+    <p class="text-center txt">©2023 !app! All Rights Reserved.</p>
   </div>
 </div>

--- a/frontend/src/app/shared/nav/nav.component.html
+++ b/frontend/src/app/shared/nav/nav.component.html
@@ -1,28 +1,27 @@
 <!-- Navbar (sticky top) -->
-<div class="w3-container w3-padding-16 w3-animate-opacity topNav">
-  <div class="w3-row w3-center">
-    <div class="w3-col s4">
-      <a routerLink="/home">
-        <i class="w3-xlarge fa fa-home home">
-          <span class="w3-hide-small signInText">Home</span>
-        </i>
-      </a>
-    </div>
-    <div class="w3-col s4"><p></p></div>
-    <div class="w3-col s4">
-      <a routerLink="/sign-up" class="w3-margin-right">
-        <i class="w3-xlarge fa fa-car signIn">
-          <span class="w3-hide-small signInText">Sign Up</span>
-        </i>
-      </a>
-      <a routerLink="/sign-in">
-        <i class="w3-xlarge fa fa-user signIn">
-          <span class="w3-hide-small signInText">Sign In</span>
-        </i>
-      </a>
+<nav class="navbar navbar-expand-lg navbar-dark w3-animate-opacity topNav">
+  <div class="container">
+    <a routerLink="/home" class="navbar-brand">
+      <i class="fs-4 fa fa-home icon">
+        <span class="d-none d-sm-inline linkText">Home</span>
+      </i>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+      <div class="navbar-nav ms-auto">
+        <a routerLink="/sign-up" class="nav-link">
+          <i class="fs-4 fa fa-car icon">
+            <span class="linkText">Sign Up</span>
+          </i>
+        </a>
+        <a routerLink="/sign-in" class="nav-link">
+          <i class="fs-4 fa fa-user icon">
+            <span class="linkText">Sign In</span>
+          </i>
+        </a>
+      </div>
     </div>
   </div>
-
-    
-</div>
-  
+</nav>

--- a/frontend/src/app/shared/nav/nav.component.scss
+++ b/frontend/src/app/shared/nav/nav.component.scss
@@ -3,18 +3,14 @@
   transition: top 0.3s;
   background-color: var(--primary);
   padding: 14px 0px;
-}
 
-.home{
-  color: var(--secondary);
-}
-
-.signIn{
-  color: var(--secondary);
-}
-
-.signInText{
-  color:  var(--white);
-  font-size: medium;
-  margin-left: 10px;
+  .icon {
+    color: var(--secondary);
+  }
+  
+  .linkText {
+    color:  var(--white);
+    font-size: medium;
+    margin-left: 10px;
+  }
 }

--- a/frontend/src/app/shared/primary-button/primary-button.component.scss
+++ b/frontend/src/app/shared/primary-button/primary-button.component.scss
@@ -15,8 +15,7 @@
   transition: 0.3s;
 
   margin: auto;
-  display: grid;  
-  margin-bottom: 64px;
+  display: grid;
 }
 
 .button:hover {background-color: var(--primary); opacity: 1;}
@@ -25,11 +24,4 @@
   background-color: var(--primary);
   box-shadow: 0 2px #666;
   transform: translateY(2px);
-}
-
-// Responsive
-@media screen and (max-width: 600px) {
-  .button{
-    margin-bottom: 32px;
-  }
 }

--- a/frontend/src/app/shared/secondary-button/secondary-button.component.scss
+++ b/frontend/src/app/shared/secondary-button/secondary-button.component.scss
@@ -15,8 +15,7 @@
   transition: 0.3s;
 
   margin: auto;
-  display: grid;  
-  margin-bottom: 64px;
+  display: grid;
 }
 
 .button:hover {background-color: var(--secondary); opacity: 1;}
@@ -25,11 +24,4 @@
   background-color: var(--secondary);
   box-shadow: 0 2px #666;
   transform: translateY(2px);
-}
-
-// Responsive
-@media screen and (max-width: 600px) {
-  .button{
-    margin-bottom: 32px;
-  }
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,10 +6,19 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1 shrink-to-fit=no">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <!-- Fonts -->
   <link href='https://fonts.googleapis.com/css?family=Noto Sans' rel='stylesheet'>
   <link href='https://fonts.googleapis.com/css?family=Inter' rel='stylesheet'>
-  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
   <script src="https://kit.fontawesome.com/cb69748332.js" crossorigin="anonymous"></script>
+  <!-- W3 Stylesheet -->
+  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+  <!-- Bootstrap -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" 
+        integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" 
+        crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" 
+          integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" 
+          crossorigin="anonymous"></script>
 </head>
 <body>
   <app-root></app-root>

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,4 +1,10 @@
 @import "utilities/variables";
+@import "utilities/mixins";
+
+* {
+    box-sizing: border-box;
+}
+
 
 body,h1,h2{
     font-family: 'Noto Sans';
@@ -27,6 +33,6 @@ p {line-height: 2}
 html {background-color: var(--background);}
 
 .container{
-    max-width: 1200px;
+    max-width: 1100px;
     margin: auto;
 }

--- a/frontend/src/utilities/_mixins.scss
+++ b/frontend/src/utilities/_mixins.scss
@@ -1,0 +1,12 @@
+$breakpoints: (
+    'xs': 575.98px,
+    'sm': 767.98px,
+    'md': 991.98px,
+    'lg': 1199.98px
+);
+
+@mixin responsive($breakpoint) {
+    @media screen and (max-width: map-get($breakpoints, $breakpoint)) {
+        @content;
+    }
+}


### PR DESCRIPTION
I couldn't get bootstrap working using the npm module, so I ended just using the cdn. The only downside is we can't take advantage of customizing bootstrap to our theme since the cdn is all css not scss. So we can leave the variables as they are.

I also setup a responsive mixin for screen sizes based on what bootstrap uses.

I tried to leave most of your code intact and only changed what was needed for bootstrap. I did leave the w3 stylesheet since it looks like all its classes are prefixed with w3, so there shouldn't be any conflicts if there are still things in there you want to use.

If you play with shrinking and enlarging your browser you can see how the new layout is responding compare to the dev site.
